### PR TITLE
chore(cicd): add envvar for espv2

### DIFF
--- a/openapi-functions.yaml
+++ b/openapi-functions.yaml
@@ -10,7 +10,7 @@ produces:
   - application/json
 paths:
   /subscription:
-    post:
+    get:
       summary: Subscribe to Turkish Vocab
       operationId: hello
       x-google-backend:

--- a/scripts/deploy_esp_endpoints.sh
+++ b/scripts/deploy_esp_endpoints.sh
@@ -10,6 +10,10 @@ output=$(gcloud run deploy $IMAGE_NAME --image="gcr.io/endpoints-release/endpoin
 CLOUD_RUN_HOSTNAME=$(echo $output | tr ' ' '\n' | grep "run.app")
 CLOUD_RUN_HOSTNAME=${CLOUD_RUN_HOSTNAME#"https://"}
 
+gcloud run services update $IMAGE_NAME \
+    --set-env-vars ENDPOINTS_SERVICE_NAME=$CLOUD_RUN_HOSTNAME \
+    --region $REGION --platform managed
+
 echo "Preparing OpenAPI Specification .."
 scripts/substitute.py openapi-functions.yaml --output openapi-render.yaml --values host=$CLOUD_RUN_HOSTNAME region=$REGION projectid=$PROJECT_ID commit=$COMMIT
 


### PR DESCRIPTION
Hi all,

this PR adds the missing `ENDPOINTS_SERVICE_NAME` to the ESPv2 instance on Google Cloud Run.

Best,
Samed