### PR TITLE
chore(cicd): add build badge to README

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -1,4 +1,4 @@
-name: PR
+name: master
 on:
   push:
     branches:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<p align="center">
-![master](https://github.com/samedguener/turkish_vocab/workflows/PR/badge.svg)
-</p>
+![master](https://github.com/samedguener/turkish_vocab/workflows/PR/badge.svg) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 ## Turkish Vocab
 This repository contains the code for the Turkish Vocab Trainer. The main goal of the project is to implement such as service using serverless functions.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![master](https://github.com/samedguener/turkish_vocab/workflows/PR/badge.svg) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![master](https://github.com/samedguener/turkish_vocab/workflows/master/badge.svg) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Turkish Vocab
 This repository contains the code for the Turkish Vocab Trainer. The main goal of the project is to implement such as service using serverless functions.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
+<p align="center">
+![master](https://github.com/samedguener/turkish_vocab/workflows/PR/badge.svg)
+</p>
 ## Turkish Vocab
 This repository contains the code for the Turkish Vocab Trainer. The main goal of the project is to implement such as service using serverless functions.


### PR DESCRIPTION
Hi all,

this PR adds following badge to the `README.md` and renames the master build workflow to `master`.

![master](https://github.com/samedguener/turkish_vocab/workflows/master/badge.svg)

Best,
Samed