### PR TITLE
chore(cicd): Remove unit test from master build 

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -16,8 +16,6 @@ jobs:
       with:
         stable: 'true'
         go-version: '1.13.7'
-    - name: Run Unit Tests
-      run: go test .
     - uses: GoogleCloudPlatform/github-actions/setup-gcloud@0.1.2
       with:
        service_account_email: ${{ secrets.GCP_SA_EMAIL_PREPRODUCTION }}


### PR DESCRIPTION
Hi all,

this PR removes the duplicated testing in the master build. As unit tests are run in PR jobs.

Best,
Samed