### PR TITLE
feat(manual_bump): Add angular commit conventions for semantic release

### DIFF
--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -16,7 +16,7 @@ jobs:
     - uses: deepakputhraya/action-pr-title@master
       with:
         regex: '([a-z\(\)])+:([a-z ])+'
-        allowed_prefixes: 'feature,chore,fix'
+        allowed_prefixes: 'feat,chore,fix,perf,docs,style,refactor'
         prefix_case_sensitive: false
         min_length: 5
         max_length: 50

--- a/.github/workflows/PR.yaml
+++ b/.github/workflows/PR.yaml
@@ -19,7 +19,7 @@ jobs:
         allowed_prefixes: 'feat,chore,fix,perf,docs,style,refactor'
         prefix_case_sensitive: false
         min_length: 5
-        max_length: 50
+        max_length: 80
     - uses: actions/setup-go@v2-beta
       with:
         stable: 'true'


### PR DESCRIPTION
Hi all,

this PR solves #16 by adding the naming conventions from [here](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type).

Best,
Samed